### PR TITLE
Add experimental FIDO2 app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Tillitis TKey FIDO2
+
+WIP support for FIDO2 using the [Tillitis](https://tillitis.se/)
+TKey USB security token.
+
+Changes might be made to the fido2 device app, causing the identity
+to change.
+
+The FIDO2 device app is a fork of Solokeys [Solo1 firmware](https://github.com/solokeys/solo1/)
+
+## Building
+
+The build scripts assume that the [TKey device libraries](https://github.com/tillitis/tkey-libs/)
+are located in `../tkey-libs`.
+
+To build, run `make tkey_app`
+
+See [Tillitis Developer Handbook](https://dev.tillitis.se/) for tool
+support.
+
+## Tkey requirements
+
+The TKey need to present itself as a USB HID device, as well as the
+usual CDC device. An experimental [branch](https://github.com/tillitis/tillitis-key1/tree/ch552_hid_cdc/),
+is available, containing bitstream for the FPGA and a firmware for
+the USB interface.
+


### PR DESCRIPTION
## Description

This PR is part of the work on issue https://github.com/tillitis/tillitis-key1/issues/218.

Forks the Solokey Solo1 repo and adds an experimental Tkey target (tkey_app).

Compatible TKey firmware, FPGA-bitstream and CH552-firmware is available in https://github.com/tillitis/tillitis-key1/tree/ch552_hid_cdc.

Registration and authentication has been successfully tested using webauthn.io in Chrome.

No persistent storage support yet. The flash memory is replaced by a fake flash memory. Memory content is kept in RAM.

## Type of change

- [x] Feature (non breaking change which adds functionality)
- [x] Documentation (a change to documentation)

## Submission checklist

- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
