### PR TITLE
Allow configuration of CC instead of hard-coding 'clang'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Main Makefile
 
+CC = clang
+
 # Directories for object files and binaries
 OBJDIR := _obj
 BINDIR := _bin

--- a/targets/tkey_app.mk
+++ b/targets/tkey_app.mk
@@ -6,8 +6,8 @@ TARGET := tkey_app
 # Programs to use for the target
 TARGET_AR      := llvm-ar
 #TARGET_AS      := llvm-as
-TARGET_AS      := clang -x assembler-with-cpp
-TARGET_CC      := clang
+TARGET_AS      := $(CC) -x assembler-with-cpp
+TARGET_CC      := $(CC)
 TARGET_CXX     :=
 TARGET_LD      := lld
 TARGET_OBJCOPY := llvm-objcopy # Set if a binary file should be created
@@ -215,4 +215,3 @@ $(TARGET)_LINKER_SCRIPT  := $(addprefix -T,$(TARGET_LINKER_SCRIPT))
 $(TARGET)_PREBUILD_CMD   := $(TARGET_PREBUILD_CMD)
 $(TARGET)_POSTBUILD_CMD  := $(TARGET_POSTBUILD_CMD)
 $(TARGET)_NEEDS_TARGETS  := $(TARGET_NEEDS_TARGETS)
-

--- a/targets/tkey_uecc.mk
+++ b/targets/tkey_uecc.mk
@@ -5,8 +5,8 @@ TARGET := tkey_uecc.a
 
 # Programs to use for the target
 TARGET_AR      := llvm-ar
-TARGET_AS      := clang -x assembler-with-cpp
-TARGET_CC      := clang
+TARGET_AS      := $(CC) -x assembler-with-cpp
+TARGET_CC      := $(CC)
 TARGET_CXX     :=
 TARGET_LD      := lld
 TARGET_OBJCOPY := llvm-objcopy # Set if a binary file should be created
@@ -149,4 +149,3 @@ $(TARGET)_LINKER_SCRIPT  := $(addprefix -T,$(TARGET_LINKER_SCRIPT))
 $(TARGET)_PREBUILD_CMD   := $(TARGET_PREBUILD_CMD)
 $(TARGET)_POSTBUILD_CMD  := $(TARGET_POSTBUILD_CMD)
 $(TARGET)_NEEDS_TARGETS  := $(TARGET_NEEDS_TARGETS)
-


### PR DESCRIPTION
Hi!  It seems `clang` is hard coded in the makefiles.  This patch allows for configuration of the compiler to use, for simpler variation between `clang-19`, `clang-20`, `clang-21` etc.  Just invoke 'make CC=clang-21' with this patch.

```
dh binary
   dh_update_autotools_config
   dh_autoreconf
   dh_auto_configure
   debian/rules override_dh_auto_build
make[1]: Entering directory '/build/tillitis-tkey-fido2-0.0~git20251204.a207c78'
make CC="clang-21 -fuse-ld=lld-21" AR=llvm-ar-21 OBJCOPY=llvm-objcopy-21 LIBDIR=/usr/share/tillitis/tkey-libs/ tkey_app
make[2]: Entering directory '/build/tillitis-tkey-fido2-0.0~git20251204.a207c78'
clang -c -MD -target riscv32-unknown-none-elf -march=rv32iczmmul -mabi=ilp32 -mcmodel=medany -Os -ffast-math -fno-common -fno-builtin-printf -fno-builtin-putchar -nostdlib -mno-relax -g -Wall -Werror=implicit-function-declaration -static -flto -DAES256=1 -DAPP_CONFIG=\"app.h\" -DDEBUG_LEVEL=2 -DuECC_PLATFORM=0  -Icrypto/cifra/src -Icrypto/cifra/src/ext -Icrypto/micro-ecc -Icrypto/sha256 -Icrypto/tiny-AES-c -Ifido2 -Ifido2/extensions -Itargets/tkey/inc -Itargets/tkey/libc/include -Itargets/tkey/libc/newlib/libc/include -Itargets/tkey/printf-embedded -Itinycbor/src -I/usr/share/tillitis/tkey-libs//include -I/usr/share/tillitis/tkey-libs//monocypher -o _obj/tkey_app/crypto/cifra/src/blockwise.o crypto/cifra/src/blockwise.c
make[2]: clang: No such file or directory
make[2]: *** [Makefile:83: _obj/tkey_app/crypto/cifra/src/blockwise.o] Error 127
make[2]: Leaving directory '/build/tillitis-tkey-fido2-0.0~git20251204.a207c78'
make[1]: *** [debian/rules:7: override_dh_auto_build] Error 2
make[1]: Leaving directory '/build/tillitis-tkey-fido2-0.0~git20251204.a207c78'
make: *** [debian/rules:4: binary] Error 2
dpkg-buildpackage: error: debian/rules binary subprocess failed with exit status 2
```