### PR TITLE
Make authenticate_credential time constant again

### DIFF
--- a/fido2/ctap.c
+++ b/fido2/ctap.c
@@ -1057,16 +1057,14 @@ int ctap_authenticate_credential(uint8_t *rp_id_lookup, uint8_t *rp_id_hash,
 	switch (desc->type) {
 	case PUB_KEY_CRED_PUB_KEY:
 
-		// Verify correct rp
-		if (!secure_memeq(desc->credential.id.rp_id_lookup,
-				  rp_id_lookup, CREDENTIAL_TAG_SIZE)) {
-			return 0;
-		}
-
-		// Derive mac and compare
+		// Verify mac and RP
+		// Deliberately use the rp_id_lookup from the request, not the
+		// credential, to make sure this request comes from the right
+		// RP.
 		make_auth_tag(rp_id_lookup, desc->credential.id.nonce,
 			      desc->credential.id.protected_metadata,
 			      desc->credential.id.count, tag);
+
 		return (secure_memeq(desc->credential.id.tag, tag,
 				     CREDENTIAL_TAG_SIZE) == 1);
 		break;


### PR DESCRIPTION
## Description
Missed a branch in the last commit, fixed in this.
Remove the first branch, it is not needed since we are verifying the bound RP when verifying the mac

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)


## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
