### PR TITLE
feat(reset): restrict authenticator reset to first 10 seconds after boot

### DIFF
--- a/fido2/inc/ctap_reset.h
+++ b/fido2/inc/ctap_reset.h
@@ -5,7 +5,9 @@
 #ifndef _CTAP_RESET_H_
 #define _CTAP_RESET_H_
 
-void ctap_reset(void);
+#include "ctap_errors.h"
+
+CtapStatus ctap_reset(void);
 void ctap_reset_state(void);
 
 #endif

--- a/fido2/src/ctap.c
+++ b/fido2/src/ctap.c
@@ -617,10 +617,7 @@ CtapStatus ctap_request(uint8_t *pkt_raw, size_t length, CTAP_RESPONSE *resp)
 
 	case CTAP_RESET:
 		printf1(TAG_CTAP, "CTAP_RESET\n");
-		status = ctap2_user_presence_test();
-		if (status.value == CTAP2_OK) {
-			ctap_reset();
-		}
+		status = ctap_reset();
 		break;
 
 	case CTAP_GET_NEXT_ASSERTION:

--- a/fido2/src/ctap_reset.c
+++ b/fido2/src/ctap_reset.c
@@ -5,12 +5,26 @@
 #include "ctap_reset.h"
 #include "crypto.h"
 #include "ctap_client_pin.h"
+#include "ctap_errors.h"
 #include "device.h"
 
 extern struct _getAssertionState getAssertionState;
 
-void ctap_reset(void)
+#define AUTHENTICATOR_RESET_TIME_MS (10 * 1000) // 10 seconds
+
+CtapStatus ctap_reset(void)
 {
+#if !(defined(DEBUG_LEVEL) && (DEBUG_LEVEL > 0))
+	if (millis() > AUTHENTICATOR_RESET_TIME_MS) {
+		return (CtapStatus){CTAP2_ERR_NOT_ALLOWED};
+	}
+#endif
+
+	CtapStatus ret = ctap2_user_presence_test();
+	if (ret.value != CTAP2_OK) {
+		return (CtapStatus){ret.value};
+	}
+
 	ctap_state_init();
 
 	authenticator_write_state(&STATE);
@@ -19,6 +33,8 @@ void ctap_reset(void)
 	ctap_client_pin_initialize();
 
 	crypto_derive_session_keys(STATE.key_salt, STATE_KEY_SALT_BYTES);
+
+	return (CtapStatus){CTAP2_OK};
 }
 
 void ctap_reset_state(void)


### PR DESCRIPTION
## Description
- According to spec one is only allowed to perform an authenticator reset during the first 10s after boot.
- Refactor ctap_reset() to return CtapStatus and move the user presence test inside the function.
- In debug builds, the check is currently bypassed to easier perform testing that requires lots of resets.
## Type of change

- [x] Feature (non breaking change which adds functionality)

## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
