### PR TITLE
fix: adapt readselect() call site to new non_blocking parameter

### DIFF
--- a/targets/tkey/src/main.c
+++ b/targets/tkey/src/main.c
@@ -72,7 +72,7 @@ int main(void)
 
 		led_set(LED_BLUE);
 
-		if (readselect(IO_CDC | IO_FIDO, &ep, &available) != 0) {
+		if (readselect(IO_CDC | IO_FIDO, false, &ep, &available) != 0) {
 			assert(1 == 2);
 		}
 


### PR DESCRIPTION
## Description

The readselect() API gained an explicit non_blocking parameter. Pass false to preserve the existing blocking behaviour in main().

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [x] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
