### PR TITLE
refactor: replace ad-hoc CDC reset handling with framed protocol

### DIFF
--- a/targets/tkey/src/main.c
+++ b/targets/tkey/src/main.c
@@ -17,6 +17,7 @@
 #include "tkey/tk1_mem.h"
 
 #define HID_PACKET_SIZE 64
+#define CMD_RESET 0xFE
 
 // clang-format off
 //static volatile uint32_t *cdi           = (volatile uint32_t *) TK1_MMIO_TK1_CDI_FIRST;
@@ -26,6 +27,11 @@ static volatile uint32_t *cpu_mon_last  = (volatile uint32_t *) TK1_MMIO_TK1_CPU
 static volatile uint32_t *app_addr      = (volatile uint32_t *) TK1_MMIO_TK1_APP_ADDR;
 static volatile uint32_t *app_size      = (volatile uint32_t *) TK1_MMIO_TK1_APP_SIZE;
 // clang-format on
+
+static void appreply_nok(struct frame_header hdr);
+static uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status,
+		      enum frame_cmdlen len);
+static void reset(uint8_t reset_type, uint8_t boot_verifier_action);
 
 int main(void)
 {
@@ -77,14 +83,70 @@ int main(void)
 		}
 
 		if (ep == IO_CDC) {
-			uint8_t b;
-			read(IO_CDC, &b, sizeof(b), 1);
-			struct reset rst = {0};
-			rst.type = b - '0' + START_DEFAULT;
-			sys_reset(&rst, 0);
-			printf2(TAG_ERR, "Device not reset\n");
-			while (1)
-				;
+			if (available >= 1) {
+				uint8_t c;
+				bool fail = false;
+				read(IO_CDC, &c, 1, 1);
+				struct frame_header hdr = {0};
+				if (frame_parse_hdr(c, &hdr) != 0) {
+					fail = true;
+				}
+
+				// Update available bytes
+				readselect(IO_CDC, true, &ep, &available);
+
+				// Frame parsing failed, discard and continue
+				if (fail) {
+					discard(IO_CDC, available);
+					continue;
+				}
+
+				// Well-behaved apps are supposed to check for a
+				// client attempting to probe for firmware. In
+				// that case destination is firmware and we just
+				// reply NOK, discarding all bytes already read.
+				if (hdr.f_domain == DST_FW) {
+					appreply_nok(hdr);
+					debug_puts("Responded NOK to message "
+						   "meant for FW\n");
+					discard(IO_CDC, available);
+					continue;
+				}
+
+				// Is it for us? If not, continue after having
+				// discarded all bytes.
+				if (hdr.f_domain != DST_SW) {
+					debug_puts("Message not meant for app. "
+						   "Endpoint was 0x");
+					debug_puthex((uint8_t)hdr.f_domain);
+					debug_lf();
+					discard(IO_CDC, available);
+					continue;
+				}
+
+				// For now, only accept a command of length 4
+				// (reset command)
+				if ((hdr.len != 4) || (available != 4)) {
+					discard(IO_CDC, available);
+					continue;
+				}
+
+				uint8_t buf[available];
+				memset(buf, 0, available);
+
+				read(IO_CDC, buf, available, available);
+				switch (buf[0]) {
+				case CMD_RESET:
+					reset(buf[1], buf[2]);
+					break;
+				default:
+					continue;
+					break;
+				}
+				printf2(TAG_ERR, "Device not reset\n");
+				while (1)
+					;
+			}
 		}
 
 		if (available != HID_PACKET_SIZE) {
@@ -119,4 +181,32 @@ int main(void)
 	printf1(TAG_GREEN, "done\n");
 	assert(1 == 2);
 	return 0;
+}
+
+// Send reply frame with response status Not OK (NOK==1), shortest length
+static void appreply_nok(struct frame_header hdr)
+{
+	uint8_t buf[2];
+	enum ioend dst = IO_CDC;
+
+	buf[0] = genhdr(hdr.id, (uint8_t)hdr.f_domain, 0x1, LEN_1);
+	buf[1] = 0; // Not used, but smallest payload is 1 byte
+
+	write(dst, buf, 2);
+}
+
+static uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status,
+		      enum frame_cmdlen len)
+{
+	return (uint8_t)((id << 5) | (endpoint << 3) | (status << 2) |
+			 (uint8_t)len);
+}
+
+static void reset(uint8_t reset_type, uint8_t boot_verifier_action)
+{
+	struct reset rst = {0};
+	rst.type = reset_type;
+	rst.next_app_data[0] = boot_verifier_action;
+
+	sys_reset(&rst, 1);
 }


### PR DESCRIPTION
## Description

The CDC endpoint now expects a properly framed command instead of a single raw byte. Frames destined for firmware are rejected with a NOK reply, frames for other destinations are silently discarded, and only frames addressed to the application are processed. Reset type and boot verifier action are passed explicitly rather than derived from the byte value.

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
