### PR TITLE
 fix(parse): unify pinUvAuthParam parsing and improve validation

### DIFF
--- a/fido2/inc/ctap.h
+++ b/fido2/inc/ctap.h
@@ -238,7 +238,7 @@ CtapStatus ctap_cbor_encode_credential_descriptor(CborEncoder *map,
 CtapStatus ctap_cbor_encode_user_entity(CborEncoder *map, CTAP_userEntity *user,
 					int is_verified);
 uint8_t ctap_check_credential_metadata(CredentialId *credential,
-				       uint8_t is_verified,
+				       bool is_verified,
 				       uint8_t is_from_credid_list,
 				       uint8_t *is_rk);
 

--- a/fido2/inc/ctap_client_pin.h
+++ b/fido2/inc/ctap_client_pin.h
@@ -91,6 +91,8 @@
  * are actually read and compared.
  */
 #define PIN_UV_AUTH_PARAM_MAX_SIZE  32
+#define PIN_UV_AUTH_PARAM_V2_SIZE   32
+#define PIN_UV_AUTH_PARAM_V1_SIZE   16
 
 /* Maximum RP ID length we will accept in a permissions request */
 #define CP_MAX_RPID_LEN             128
@@ -103,7 +105,7 @@ typedef struct {
 	uint8_t keyAgreementPresent;
 	// pinUvAuthParam: 16 bytes for protocol 1, 32 bytes for protocol 2
 	uint8_t pinUvAuthParam[PIN_UV_AUTH_PARAM_MAX_SIZE];
-	uint8_t pinUvAuthParam_present;
+	uint8_t pinUvAuthParam_len;
 	uint8_t newPinEnc[NEW_PIN_ENC_MAX_SIZE];
 	uint8_t newPinEncSize;
 	uint8_t pinHashEnc[32]; // 16 bytes proto-1, 32 bytes proto-2

--- a/fido2/inc/ctap_credential_management.h
+++ b/fido2/inc/ctap_credential_management.h
@@ -67,7 +67,7 @@ typedef struct {
 	uint32_t subCommandParamsCborSize;
 
 	uint8_t pinUvAuthParam[PIN_UV_AUTH_PARAM_MAX_SIZE];
-	uint8_t pinUvAuthParam_present;
+	uint8_t pinUvAuthParam_len;
 	uint8_t pinProtocol;
 } CTAP_credMgmt;
 

--- a/fido2/inc/ctap_get_assertion.h
+++ b/fido2/inc/ctap_get_assertion.h
@@ -48,13 +48,13 @@ typedef struct {
 	uint8_t up;
 
 	uint8_t pinUvAuthParam[PIN_UV_AUTH_PARAM_MAX_SIZE];
-	uint8_t pinUvAuthParam_present;
+	uint8_t pinUvAuthParam_len;
 	// pinUvAuthParam_empty is true iff an empty bytestring was provided as
-	// pinUvAuthParam. This is exclusive with |pinUvAuthParam_present|. It
+	// pinUvAuthParam. This is exclusive with |pinUvAuthParam_len|. It
 	// exists because an empty pinUvAuthParam is a special signal to block
 	// for touch. See
 	// https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#using-pinToken-in-authenticatorGetAssertion
-	uint8_t pinUvAuthParam_empty;
+	bool pinUvAuthParam_empty;
 	uint8_t pinProtocol;
 
 	CTAP_credentialDescriptor *creds;

--- a/fido2/inc/ctap_make_credential.h
+++ b/fido2/inc/ctap_make_credential.h
@@ -49,13 +49,13 @@ typedef struct {
 	uint8_t up;
 
 	uint8_t pinUvAuthParam[PIN_UV_AUTH_PARAM_MAX_SIZE];
-	uint8_t pinUvAuthParam_present;
+	uint8_t pinUvAuthParam_len;
 	// pinUvAuthParam_empty is true iff an empty bytestring was provided as
-	// pinUvAuthParam. This is exclusive with |pinUvAuthParam_present|. It
+	// pinUvAuthParam. This is exclusive with |pinUvAuthParam_len|. It
 	// exists because an empty pinUvAuthParam is a special signal to block
 	// for touch. See
 	// https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#using-pinToken-in-authenticatorMakeCredential
-	uint8_t pinUvAuthParam_empty;
+	bool pinUvAuthParam_empty;
 	uint8_t pinProtocol;
 	CTAP_extensions extensions;
 	CborParser parser;

--- a/fido2/inc/ctap_parse.h
+++ b/fido2/inc/ctap_parse.h
@@ -40,6 +40,8 @@ CtapStatus ctap_parse_fixed_length_byte_string(CborValue *map, uint8_t *dst,
 					       unsigned int len);
 CtapStatus ctap_parse_options(CborValue *val, uint8_t *rk, uint8_t *uv,
 			      uint8_t *up);
+CtapStatus ctap_parse_pinUvAuthParam(CborValue *map, bool *empty,
+				     uint8_t *pinUvAuthParam, uint8_t *len);
 CtapStatus
 ctap_parse_pubkey_credential_descriptor(CborValue *arr,
 					CTAP_credentialDescriptor *cred);

--- a/fido2/src/ctap.c
+++ b/fido2/src/ctap.c
@@ -156,7 +156,7 @@ CtapStatus ctap_cbor_encode_user_entity(CborEncoder *map, CTAP_userEntity *user,
 }
 
 uint8_t ctap_check_credential_metadata(CredentialId *credential,
-				       uint8_t is_verified,
+				       bool is_verified,
 				       uint8_t is_from_credid_list,
 				       uint8_t *is_rk)
 {

--- a/fido2/src/ctap_client_pin.c
+++ b/fido2/src/ctap_client_pin.c
@@ -198,7 +198,7 @@ CtapStatus ctap_client_pin(CborEncoder *encoder, uint8_t *request,
 	case CP_SubCmd_setPIN:
 		printf1(TAG_CP, "CP_SubCmd_setPIN\n");
 
-		if (!CP.newPinEncSize || !CP.pinUvAuthParam_present ||
+		if (CP.newPinEncSize == 0 || CP.pinUvAuthParam_len == 0 ||
 		    !CP.keyAgreementPresent) {
 			return (CtapStatus){CTAP2_ERR_MISSING_PARAMETER};
 		}
@@ -238,7 +238,7 @@ CtapStatus ctap_client_pin(CborEncoder *encoder, uint8_t *request,
 			return (CtapStatus){CTAP2_ERR_PIN_NOT_SET};
 		}
 
-		if (!CP.newPinEncSize || !CP.pinUvAuthParam_present ||
+		if (CP.newPinEncSize == 0 || CP.pinUvAuthParam_len == 0 ||
 		    !CP.keyAgreementPresent || !CP.pinHashEncPresent) {
 			return (CtapStatus){CTAP2_ERR_MISSING_PARAMETER};
 		}
@@ -846,21 +846,19 @@ static CtapStatus parse_client_pin_request(CTAP_clientPin *CP, uint8_t *request,
 
 		case CP_Cmd_pinUvAuthParam:
 			printf1(TAG_CP, "CP_Cmd_pinUvAuthParam\n");
-			/*
-			 * We don't yet know the protocol when parsing (it may
-			 * appear later in the map), so we accept both sizes.
-			 * The size is validated in ctap_client_pin() once
-			 * pinProtocol is known. Store up to
-			 * PIN_UV_AUTH_PARAM_MAX_SIZE bytes.
-			 */
-			if (cbor_value_get_type(&map) != CborByteStringType) {
-				return (CtapStatus){CTAP2_ERR_INVALID_CBOR};
+
+			bool pinUvAuthToken_empty = false;
+			ctap_ret = ctap_parse_pinUvAuthParam(
+			    &map, &pinUvAuthToken_empty, CP->pinUvAuthParam,
+			    &CP->pinUvAuthParam_len);
+			ctap_check_retr(ctap_ret);
+
+			if (pinUvAuthToken_empty) {
+				// Not supposed to happen here, special case for
+				// MC and GA
+				return (CtapStatus){CTAP1_ERR_INVALID_LENGTH};
 			}
-			sz = PIN_UV_AUTH_PARAM_MAX_SIZE;
-			cbor_ret = cbor_value_copy_byte_string(
-			    &map, CP->pinUvAuthParam, &sz, NULL);
-			cbor_check_ret(cbor_ret);
-			CP->pinUvAuthParam_present = 1;
+
 			break;
 
 		case CP_Cmd_newPinEnc:

--- a/fido2/src/ctap_credential_management.c
+++ b/fido2/src/ctap_credential_management.c
@@ -608,11 +608,19 @@ static CtapStatus parse_credential_management_request(CTAP_credMgmt *CM,
 
 		case CM_Cmd_pinUvAuthParam:
 			printf1(TAG_PARSE, "CM_Cmd_pinUvAuthParam\n");
-			ctap_ret = ctap_parse_fixed_length_byte_string(
-			    &map, CM->pinUvAuthParam,
-			    PIN_UV_AUTH_PARAM_MAX_SIZE);
+
+			bool pinUvAuthToken_empty = false;
+			ctap_ret = ctap_parse_pinUvAuthParam(
+			    &map, &pinUvAuthToken_empty, CM->pinUvAuthParam,
+			    &CM->pinUvAuthParam_len);
 			ctap_check_retr(ctap_ret);
-			CM->pinUvAuthParam_present = 1;
+
+			if (pinUvAuthToken_empty) {
+				// Not supposed to happen here, special case for
+				// MC and GA
+				return (CtapStatus){CTAP1_ERR_INVALID_LENGTH};
+			}
+
 			break;
 		}
 		cbor_ret = cbor_value_advance(&map);
@@ -926,7 +934,7 @@ static CtapStatus verify_pin_auth_for_credential_management(CTAP_credMgmt *CM)
 		return (CtapStatus){CTAP2_OK};
 	}
 
-	if (!CM->pinUvAuthParam_present) {
+	if (CM->pinUvAuthParam_len == 0) {
 		return (CtapStatus){CTAP2_ERR_PUAT_REQUIRED};
 	}
 

--- a/fido2/src/ctap_get_assertion.c
+++ b/fido2/src/ctap_get_assertion.c
@@ -66,7 +66,7 @@ CtapStatus ctap_get_assertion(CborEncoder *encoder, uint8_t *request,
 
 	// If pinUvAuthParam is present and the authenticator is protected, do
 	// verification. If not, continue but set user_verifier = 0.
-	if (GA.pinUvAuthParam_present) {
+	if (GA.pinUvAuthParam_len > 0) {
 		if (GA.pinProtocol == 0) {
 			return (CtapStatus){CTAP2_ERR_MISSING_PARAMETER};
 		}
@@ -155,16 +155,13 @@ CtapStatus ctap_get_assertion(CborEncoder *encoder, uint8_t *request,
 		device_disable_up(false);
 		ctap_check_retr(ctap_ret);
 
-		// if user presence is collected
-		if (getAssertionState.buf.authData.flags & 0x01) {
-			if (GA.pinUvAuthParam_present) {
-				ctap_client_pin_clear_user_present(
-				    GA.pinProtocol);
-				ctap_client_pin_clear_user_verified(
-				    GA.pinProtocol);
-				ctap_client_pin_clear_PinUvAuthToken_permissions_except_Lbw(
-				    GA.pinProtocol);
-			}
+		// If the "up" option is set to true or not present - clear the
+		// pin flags
+		if (GA.up == 1 || GA.up == 0xff) {
+			ctap_client_pin_clear_user_present(GA.pinProtocol);
+			ctap_client_pin_clear_user_verified(GA.pinProtocol);
+			ctap_client_pin_clear_PinUvAuthToken_permissions_except_Lbw(
+			    GA.pinProtocol);
 		}
 
 		// Update UV-bit
@@ -445,7 +442,7 @@ static CtapStatus parse_get_assertion_request(CTAP_getAssertion *GA,
 
 	memset(GA, 0, sizeof(CTAP_getAssertion));
 	GA->creds = getAssertionState.creds; // Save stack memory
-	GA->up = 0xff;
+	GA->up = 0xff;			     // Show that it is not present
 
 	cbor_ret = cbor_parser_init(request, length,
 				    CborValidateCanonicalFormat, &parser, &it);
@@ -522,37 +519,11 @@ static CtapStatus parse_get_assertion_request(CTAP_getAssertion *GA,
 
 		case GA_Cmd_pinUvAuthParam:
 			printf1(TAG_GA, "GA_Cmd_pinUvAuthParam\n");
-
-			size_t pinSize;
-			if (cbor_value_get_type(&map) != CborByteStringType) {
-				printf2(TAG_ERR, "Error, expecting byte string "
-						 "for map key\n");
-				return (CtapStatus){CTAP2_ERR_INVALID_CBOR};
-			}
-			if (cbor_value_get_string_length(&map, &pinSize) !=
-			    CborNoError) {
-				printf2(TAG_ERR, "Error, invalid map data\n");
-				return (CtapStatus){CTAP2_ERR_INVALID_CBOR};
-			}
-			if (pinSize == 0) {
-				GA->pinUvAuthParam_empty = 1;
-				break;
-			}
-
-			ctap_ret = ctap_parse_fixed_length_byte_string(
-			    &map, GA->pinUvAuthParam,
-			    PIN_UV_AUTH_PARAM_MAX_SIZE);
-			if (CTAP1_ERR_INVALID_LENGTH !=
-			    ctap_ret.value) // damn microsoft
-			{
-				ctap_check_retr(ctap_ret);
-
-			} else {
-				ctap_ret = (CtapStatus){CTAP2_OK};
-			}
-
+			ctap_ret = ctap_parse_pinUvAuthParam(
+			    &map, &GA->pinUvAuthParam_empty, GA->pinUvAuthParam,
+			    &GA->pinUvAuthParam_len);
 			ctap_check_retr(ctap_ret);
-			GA->pinUvAuthParam_present = 1;
+
 			break;
 
 		case GA_Cmd_pinUvAuthProtocol:

--- a/fido2/src/ctap_make_credential.c
+++ b/fido2/src/ctap_make_credential.c
@@ -63,12 +63,12 @@ CtapStatus ctap_make_credential(CborEncoder *encoder, uint8_t *request,
 
 	// TODO:: This needs to be verified against spec
 	if (ctap_client_pin_is_set()) {
-		if (MC.pinUvAuthParam_present == 0) {
+		if (MC.pinUvAuthParam_len == 0) {
 			printf2(TAG_ERR, "Error, pinUvAuthParam is required\n");
 			return (CtapStatus){CTAP2_ERR_PUAT_REQUIRED};
 		}
 
-		if (ctap_client_pin_is_set() || (MC.pinUvAuthParam_present)) {
+		if (ctap_client_pin_is_set() || (MC.pinUvAuthParam_len > 0)) {
 			ctap_ret = ctap_client_pin_verify_auth(
 			    MC.pinUvAuthParam, MC.clientDataHash,
 			    MC.pinProtocol);
@@ -127,8 +127,11 @@ CtapStatus ctap_make_credential(CborEncoder *encoder, uint8_t *request,
 		}
 
 		uint8_t is_rk = 0;
+
+		bool user_verified =
+		    ctap_client_pin_get_user_verified(MC.pinProtocol);
 		if (ctap_check_credential_metadata(&excl_cred->credential.id,
-						   MC.pinUvAuthParam_present, 1,
+						   user_verified, 1,
 						   &is_rk) == 0) {
 
 			if (is_rk) {
@@ -520,27 +523,11 @@ static CtapStatus parse_make_credential(CTAP_makeCredential *MC,
 
 		case MC_Cmd_pinUvAuthParam:
 			printf1(TAG_MC, "MC_Cmd_pinUvAuthParam\n");
+			ctap_ret = ctap_parse_pinUvAuthParam(
+			    &map, &MC->pinUvAuthParam_empty, MC->pinUvAuthParam,
+			    &MC->pinUvAuthParam_len);
+			ctap_check_retr(ctap_ret);
 
-			size_t pinSize;
-			if (cbor_value_get_type(&map) == CborByteStringType &&
-			    cbor_value_get_string_length(&map, &pinSize) ==
-				CborNoError &&
-			    pinSize == 0) {
-				MC->pinUvAuthParam_empty = 1;
-				break;
-			}
-
-			ctap_ret = ctap_parse_fixed_length_byte_string(
-			    &map, MC->pinUvAuthParam,
-			    PIN_UV_AUTH_PARAM_MAX_SIZE);
-			if (CTAP1_ERR_INVALID_LENGTH !=
-			    ctap_ret.value) // damn microsoft
-			{
-				ctap_check_retr(ctap_ret);
-			} else {
-				ctap_ret.value = CTAP2_OK;
-			}
-			MC->pinUvAuthParam_present = 1;
 			break;
 
 		case MC_Cmd_pinUvAuthProtocol:

--- a/fido2/src/ctap_parse.c
+++ b/fido2/src/ctap_parse.c
@@ -11,6 +11,7 @@
 #include "log.h"
 #include "u2f.h"
 #include "util.h"
+#include <ctap_client_pin.h>
 
 void _cbor_check_ret(CborError ret, int line, const char *filename)
 {
@@ -236,6 +237,57 @@ CtapStatus ctap_parse_options(CborValue *val, uint8_t *rk, uint8_t *uv,
 		cbor_ret = cbor_value_advance(&map);
 		cbor_check_ret(cbor_ret);
 	}
+
+	return (CtapStatus){CTAP2_OK};
+}
+
+/*
+ * ctap_parse_pinUvAuthParam - Parse pinUvAuthParam from a CBOR map value.
+ *
+ * Validates that @map is a CBOR byte string, copies its contents into
+ * @pinUvAuthParam, and verifies the length matches either
+ * PIN_UV_AUTH_PARAM_V1_SIZE or PIN_UV_AUTH_PARAM_V2_SIZE.
+ * The parsed length is written to @len, and has to be furhter validated at a
+ * later stage when the protocol version is known.
+ *
+ * @pinUvAuthParam should be at least PIN_UV_AUTH_PARAM_MAX_SIZE bytes.
+ *
+ * Returns a CtapStatus indicating success or the appropriate CTAP error.
+ */
+CtapStatus ctap_parse_pinUvAuthParam(CborValue *map, bool *empty,
+				     uint8_t *pinUvAuthParam, uint8_t *len)
+{
+	/*
+	 * We don't yet know the protocol when parsing (it may
+	 * appear later in the map), so we accept both sizes.
+	 */
+	size_t sz = 0;
+	CborError cbor_ret;
+	*len = 0;
+
+	if (cbor_value_get_type(map) != CborByteStringType) {
+		return (CtapStatus){CTAP2_ERR_INVALID_CBOR};
+	}
+	if (cbor_value_get_string_length(map, &sz) != CborNoError) {
+		printf2(TAG_ERR, "Error, invalid map data\n");
+		return (CtapStatus){CTAP2_ERR_INVALID_CBOR};
+	}
+	if (sz == 0) {
+		*empty = true;
+		return (CtapStatus){CTAP2_OK};
+	}
+
+	sz = PIN_UV_AUTH_PARAM_MAX_SIZE;
+	cbor_ret = cbor_value_copy_byte_string(map, pinUvAuthParam, &sz, NULL);
+	cbor_check_ret(cbor_ret);
+	*len = (uint8_t)sz;
+
+	if (sz != PIN_UV_AUTH_PARAM_V2_SIZE &&
+	    sz != PIN_UV_AUTH_PARAM_V1_SIZE) {
+		return (CtapStatus){CTAP1_ERR_INVALID_LENGTH};
+	}
+	// TODO: Previously a comment said "Damn Microsoft" and
+	// masked the CTAP1_ERR_INVALID_LENGTH error.
 
 	return (CtapStatus){CTAP2_OK};
 }


### PR DESCRIPTION
## Description
Introduce `ctap_parse_pinUvAuthParam()` to replace duplicated parsing logic across ClientPIN, GetAssertion, MakeCredential, and CredentialManagement.

- Rename `pinUvAuthParam_present` to `pinUvAuthParam_len` to track the actual byte length instead of a boolean flag.
- Enforce that the parameter is exactly 16 (v1) or 32 (v2) bytes during parse time.
- Fix GetAssertion to clear PIN token flags based on the `up` option rather than the returned authData flags.
- Fix MakeCredential to pass the actual UV state to `ctap_check_credential_metadata()` instead of raw parameter presence.
- Remove legacy workarounds masking invalid-length errors. If this is true error, a workaround has to be re-introduced.

Fixes #92 

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)
- [ ] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
