### PR TITLE
refactor(tkey): invert LED state, off unless waiting for touch

### DIFF
--- a/targets/tkey/src/device.c
+++ b/targets/tkey/src/device.c
@@ -239,7 +239,7 @@ int ctap_user_presence_test(uint32_t up_delay)
 	*touch = 0;
 	do {
 		if (*touch & (1 << TK1_MMIO_TOUCH_STATUS_EVENT_BIT)) {
-			led_set(LED_GREEN | LED_RED);
+			led_set(LED_BLACK);
 			return 1;
 		}
 

--- a/targets/tkey/src/main.c
+++ b/targets/tkey/src/main.c
@@ -43,7 +43,7 @@ int main(void)
 	*cpu_mon_last = TK1_RAM_BASE + TK1_RAM_SIZE;
 	*cpu_mon_ctrl = 1;
 
-	led_set(LED_BLUE);
+	led_set(LED_BLACK);
 
 	// clang-format off
 	set_logging_mask(
@@ -75,8 +75,6 @@ int main(void)
 	while (1) {
 		enum ioend ep;
 		uint8_t available;
-
-		led_set(LED_BLUE);
 
 		if (readselect(IO_CDC | IO_FIDO, false, &ep, &available) != 0) {
 			assert(1 == 2);
@@ -167,7 +165,6 @@ int main(void)
 		}
 
 		if (usbhid_recv(hidmsg) > 0) {
-			led_set(LED_GREEN | LED_RED);
 			ctaphid_handle_packet(hidmsg);
 			memset(hidmsg, 0, sizeof(hidmsg));
 		} else {


### PR DESCRIPTION
## Description

Removes active LED signaling during processing, LED are now kept off rather than indicating power-on and processing. Will blink as a promt for user to assert presence.

## Type of change
- [x] Feature (non breaking change which adds functionality)

## Submission checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
