### PR TITLE
refactor: reset on unrecoverable boot errors

### DIFF
--- a/fido2/inc/ctap.h
+++ b/fido2/inc/ctap.h
@@ -254,7 +254,7 @@ size_t ctap_encode_der_sig(uint8_t const *const in_sigbuf,
 void ctap_flush_state(void);
 size_t ctap_get_credential_id_size(int type);
 void ctap_increment_rk_store(void);
-void ctap_init(void);
+int ctap_init(void);
 CtapStatus ctap_make_auth_data(struct rpId *rp, uint8_t *rp_id_hash,
 			       uint8_t *rp_id_lookup, uint8_t *auth_data_buf,
 			       size_t *len, CTAP_credInfo *credInfo,

--- a/fido2/inc/device.h
+++ b/fido2/inc/device.h
@@ -202,7 +202,7 @@ int ctap_overwrite_rk(const CTAP_residentKey *rk);
  */
 void device_wink(void);
 
-void device_init(void);
+uint8_t device_init(void);
 void usbhid_init(void);
 void usbhid_close(void);
 int usbhid_recv(uint8_t *msg);

--- a/fido2/src/ctap.c
+++ b/fido2/src/ctap.c
@@ -319,7 +319,8 @@ void ctap_increment_rk_store(void)
 }
 
 //  Run ctap related power-up procedures (init pinToken, generate shared secret)
-void ctap_init(void)
+//  Returns zero on success, -1 if the app is not allowed to start.
+int ctap_init(void)
 {
 	app_version_t app_version = version_get_version();
 	printf1(TAG_GREEN, "Current app version: %d.%d.%d\n", app_version.major,
@@ -346,11 +347,7 @@ void ctap_init(void)
 
 	if (ret < 0) {
 		printf1(TAG_ERR, "App version not allowed to start\n");
-		// TODO: Asses the right response
-		led_set(LED_RED);
-		while (1) {
-			;
-		}
+		return -1;
 	} else if (ret > 0) {
 		printf1(TAG_GREEN, "App version update\n");
 		// If any data migration is needed, it should typically be
@@ -374,6 +371,7 @@ void ctap_init(void)
 	}
 
 	ctap_client_pin_initialize();
+	return 0;
 }
 
 CtapStatus ctap_make_auth_data(struct rpId *rp, uint8_t *rp_id_hash,

--- a/fido2/src/ctaphid.c
+++ b/fido2/src/ctaphid.c
@@ -80,7 +80,6 @@ void ctaphid_init(void)
 {
 	state = IDLE;
 	buffer_reset();
-	// ctap_reset_state();
 }
 
 static uint32_t get_new_cid(void)

--- a/targets/tkey/src/device.c
+++ b/targets/tkey/src/device.c
@@ -78,15 +78,30 @@ void device_reboot(void)
 	assert(1 == 2);
 }
 
-void device_init(void)
+// Initializes the device
+// Returns zero on success.
+// On error it returns:
+// 2: file system corrupted and non-recoverable
+// 3: app is not allowed to start, wrong version
+uint8_t device_init(void)
 {
 	hw_init();
-	// usbhid_init();
 	ctaphid_init();
-	ctap_init();
+
+	// fs_init should come before ctap_init
+	if (fs_init() != 0) {
+		return 2;
+	}
+
+	if (ctap_init() < 0) {
+		return 3;
+	}
 
 	// For now make make sure the folder RK exists.
-	fs_create_dir("rk");
+	if (fs_create_dir("rk")) {
+		return 2;
+	}
+	return 0;
 }
 
 void usbhid_init(void)

--- a/targets/tkey/src/init.c
+++ b/targets/tkey/src/init.c
@@ -10,8 +10,6 @@
 #include "rng.h"
 #include "timer.h"
 
-#include "fs.h"
-
 // clang-format off
 static volatile uint32_t *timer =           (volatile uint32_t *)TK1_MMIO_TIMER_TIMER;
 static volatile uint32_t *timer_prescaler = (volatile uint32_t *)TK1_MMIO_TIMER_PRESCALER;
@@ -26,10 +24,6 @@ void hw_init(void)
 	init_usb();
 #endif
 	rng_init();
-
-	if (fs_init() != 0) {
-		assert(1 == 2);
-	}
 }
 
 void init_millisecond_timer(void)

--- a/targets/tkey/src/main.c
+++ b/targets/tkey/src/main.c
@@ -18,6 +18,7 @@
 
 #define HID_PACKET_SIZE 64
 #define CMD_RESET 0xFE
+#define FLASH_ERROR_DELAY_MS 500
 
 // clang-format off
 //static volatile uint32_t *cdi           = (volatile uint32_t *) TK1_MMIO_TK1_CDI_FIRST;
@@ -32,6 +33,7 @@ static void appreply_nok(struct frame_header hdr);
 static uint8_t genhdr(uint8_t id, uint8_t endpoint, uint8_t status,
 		      enum frame_cmdlen len);
 static void reset(uint8_t reset_type, uint8_t boot_verifier_action);
+static void error_signal_and_exit_app(uint8_t err);
 
 int main(void)
 {
@@ -68,7 +70,10 @@ int main(void)
 	    0);
 	// clang-format on
 
-	device_init();
+	uint8_t err = device_init();
+	if (err != 0) {
+		error_signal_and_exit_app(err);
+	}
 
 	memset(hidmsg, 0, sizeof(hidmsg));
 
@@ -206,4 +211,21 @@ static void reset(uint8_t reset_type, uint8_t boot_verifier_action)
 	rst.next_app_data[0] = boot_verifier_action;
 
 	sys_reset(&rst, 1);
+}
+
+// Signals the error by flashing the LED the number of times as the error value.
+// Then resets into the boot verifier command mode.
+static void error_signal_and_exit_app(uint8_t err)
+{
+	for (uint8_t i = 0; i < err; i++) {
+		led_set(LED_RED);
+		delay(FLASH_ERROR_DELAY_MS);
+		led_set(LED_BLACK);
+		delay(FLASH_ERROR_DELAY_MS);
+	}
+	// Keep debug output after blink to increase the chance that the
+	// USB-controller is ready
+	printf2(TAG_ERR, "device_init failed (%d)\n", err);
+	delay(200);
+	reset(START_FLASH0, 1);
 }


### PR DESCRIPTION
## Description

Prevent the risk of bricking a device by change ctap_init() and device_init() to return error codes instead of looping forever or asserting. Move fs_init() into device_init() to ensure correct ordering. Signal init failures via LED flashes in main() before resetting to boot-verifier, to give the user a chance to understand what went wrong.

Two flashes means files system corruption
Three flashes means that the app was not allowed to start

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
