### PR TITLE
fix: send CTAPHID keepalive continuously during user presence test

### DIFF
--- a/fido2/src/ctap.c
+++ b/fido2/src/ctap.c
@@ -46,7 +46,6 @@ static void truncate_rpid(uint8_t *stored_rpid, uint8_t *stored_len,
 
 CtapStatus ctap2_user_presence_test(void)
 {
-	device_set_status(CTAPHID_STATUS_UPNEEDED);
 	int ret = ctap_user_presence_test(CTAP2_UP_DELAY_MS);
 	if (ret > 0) {
 		return (CtapStatus){CTAP2_OK};

--- a/targets/tkey/src/device.c
+++ b/targets/tkey/src/device.c
@@ -59,7 +59,7 @@ uint32_t millis(void)
 
 void device_set_status(uint8_t status)
 {
-	if (status != CTAPHID_STATUS_IDLE && __device_status != status) {
+	if (status != CTAPHID_STATUS_IDLE) {
 		ctaphid_update_status(status);
 	}
 	__device_status = status;
@@ -255,8 +255,12 @@ int ctap_user_presence_test(uint32_t up_delay)
 	do {
 		if (*touch & (1 << TK1_MMIO_TOUCH_STATUS_EVENT_BIT)) {
 			led_set(LED_BLACK);
+			device_set_status(CTAPHID_STATUS_PROCESSING);
+
 			return 1;
 		}
+
+		device_set_status(CTAPHID_STATUS_UPNEEDED);
 
 		time = millis();
 		led_on = ((time - start_time) / 100 % 2);


### PR DESCRIPTION
## Description
Prevent a host from timing out when waiting for user presence.
This does not fix the general keepalive of `PROCESSING` that should be sent in the rest of the application. 

## Type of change
- [x] Bugfix (non breaking change which resolve an issue)


## Submission checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
