### PR TITLE
debug: add debug boot delay to allow attaching a debugger/serial monitor

### DIFF
--- a/targets/tkey/src/init.c
+++ b/targets/tkey/src/init.c
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Tillitis AB <tillitis.se>
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#include "tkey/debug.h"
 #include <assert.h>
 #include <stdint.h>
 #include <tkey/io.h>
@@ -17,11 +18,32 @@ static volatile uint32_t *timer_ctrl =      (volatile uint32_t *)TK1_MMIO_TIMER_
 // clang-format on
 #define CPUFREQ 24000000
 
+#ifdef TKEY_DEBUG
+static uint32_t millis(void)
+{
+	uint32_t timer_val = *timer;
+	if (timer_val <= 1) {
+		assert(1 == 2);
+	}
+	return TIMER_MAX - timer_val;
+}
+
+static void delay(uint32_t ms)
+{
+	uint32_t time = millis();
+	while ((millis() - time) < ms)
+		;
+}
+#endif
+
 void hw_init(void)
 {
 	init_millisecond_timer();
 #ifndef QEMU_DEBUG
 	init_usb();
+#endif
+#ifdef TKEY_DEBUG
+	delay(2000);
 #endif
 	rng_init();
 }


### PR DESCRIPTION
## Description

- Add millis()/delay() helpers under TKEY_DEBUG, built on the existing millisecond timer
- Insert a 2 second delay in hw_init() when TKEY_DEBUG is defined, giving time to attach before the rest of init proceeds
- Include tkey/debug.h

## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
