### PR TITLE
tkey: gate CDC and FIDO handling on endpoint match, poll in readselect

### DIFF
--- a/targets/tkey/src/main.c
+++ b/targets/tkey/src/main.c
@@ -81,92 +81,92 @@ int main(void)
 		enum ioend ep;
 		uint8_t available;
 
-		if (readselect(IO_CDC | IO_FIDO, false, &ep, &available) != 0) {
+		if (readselect(IO_CDC | IO_FIDO, true, &ep, &available) != 0) {
 			assert(1 == 2);
 		}
 
-		if (ep == IO_CDC) {
-			if (available >= 1) {
-				uint8_t c;
-				bool fail = false;
-				read(IO_CDC, &c, 1, 1);
-				struct frame_header hdr = {0};
-				if (frame_parse_hdr(c, &hdr) != 0) {
-					fail = true;
-				}
-
-				// Update available bytes
-				readselect(IO_CDC, true, &ep, &available);
-
-				// Frame parsing failed, discard and continue
-				if (fail) {
-					discard(IO_CDC, available);
-					continue;
-				}
-
-				// Well-behaved apps are supposed to check for a
-				// client attempting to probe for firmware. In
-				// that case destination is firmware and we just
-				// reply NOK, discarding all bytes already read.
-				if (hdr.f_domain == DST_FW) {
-					appreply_nok(hdr);
-					debug_puts("Responded NOK to message "
-						   "meant for FW\n");
-					discard(IO_CDC, available);
-					continue;
-				}
-
-				// Is it for us? If not, continue after having
-				// discarded all bytes.
-				if (hdr.f_domain != DST_SW) {
-					debug_puts("Message not meant for app. "
-						   "Endpoint was 0x");
-					debug_puthex((uint8_t)hdr.f_domain);
-					debug_lf();
-					discard(IO_CDC, available);
-					continue;
-				}
-
-				// For now, only accept a command of length 4
-				// (reset command)
-				if ((hdr.len != 4) || (available != 4)) {
-					discard(IO_CDC, available);
-					continue;
-				}
-
-				uint8_t buf[available];
-				memset(buf, 0, available);
-
-				read(IO_CDC, buf, available, available);
-				switch (buf[0]) {
-				case CMD_RESET:
-					reset(buf[1], buf[2]);
-					break;
-				default:
-					continue;
-					break;
-				}
-				printf2(TAG_ERR, "Device not reset\n");
-				while (1)
-					;
+		if ((ep == IO_CDC) && (available >= 1)) {
+			uint8_t c;
+			bool fail = false;
+			read(IO_CDC, &c, 1, 1);
+			struct frame_header hdr = {0};
+			if (frame_parse_hdr(c, &hdr) != 0) {
+				fail = true;
 			}
+
+			// Update available bytes
+			readselect(IO_CDC, true, &ep, &available);
+
+			// Frame parsing failed, discard and continue
+			if (fail) {
+				discard(IO_CDC, available);
+				continue;
+			}
+
+			// Well-behaved apps are supposed to check for a
+			// client attempting to probe for firmware. In
+			// that case destination is firmware and we just
+			// reply NOK, discarding all bytes already read.
+			if (hdr.f_domain == DST_FW) {
+				appreply_nok(hdr);
+				debug_puts("Responded NOK to message "
+					   "meant for FW\n");
+				discard(IO_CDC, available);
+				continue;
+			}
+
+			// Is it for us? If not, continue after having
+			// discarded all bytes.
+			if (hdr.f_domain != DST_SW) {
+				debug_puts("Message not meant for app. "
+					   "Endpoint was 0x");
+				debug_puthex((uint8_t)hdr.f_domain);
+				debug_lf();
+				discard(IO_CDC, available);
+				continue;
+			}
+
+			// For now, only accept a command of length 4
+			// (reset command)
+			if ((hdr.len != 4) || (available != 4)) {
+				discard(IO_CDC, available);
+				continue;
+			}
+
+			uint8_t buf[available];
+			memset(buf, 0, available);
+
+			read(IO_CDC, buf, available, available);
+			switch (buf[0]) {
+			case CMD_RESET:
+				reset(buf[1], buf[2]);
+				break;
+			default:
+				continue;
+				break;
+			}
+			printf2(TAG_ERR, "Device not reset\n");
+			while (1)
+				;
 		}
 
-		if (available != HID_PACKET_SIZE) {
-			// Discard data
-			printf2(TAG_ERR,
-				"Got incomplete HID frame, discard.\n");
-			read(IO_FIDO, data, sizeof(data), available);
-			continue;
-		}
+		if ((ep == IO_FIDO) && (available >= 1)) {
+			if (available != HID_PACKET_SIZE) {
+				// Discard data
+				printf2(TAG_ERR, "Got incomplete HID "
+						 "frame, discard.\n");
+				discard(IO_FIDO, available);
+				continue;
+			}
 
-		if (read(IO_FIDO, data, sizeof(data), available) !=
-		    HID_PACKET_SIZE) {
-			assert(1 == 2);
-		}
+			if (read(IO_FIDO, data, sizeof(data), available) !=
+			    HID_PACKET_SIZE) {
+				assert(1 == 2);
+			}
 
-		if (fifo_hidmsg_add(data) != 0) {
-			return -1;
+			if (fifo_hidmsg_add(data) != 0) {
+				assert(1 == 2);
+			}
 		}
 
 		if (usbhid_recv(hidmsg) > 0) {


### PR DESCRIPTION
## Description

- Change readselect() to non-blocking (true) instead of blocking (false) to be able to process data that have been put into the fifo from other places than main.
- Guard the FIDO frame length check, read(), and fifo_hidmsg_add() behind `(ep == IO_FIDO) && (available >= 1)`, since these previously ran unconditionally even when the received data came from IO_CDC
- Use discard() instead of read() to drop incomplete HID frames
- Replace the fifo_hidmsg_add() failure's `return -1` with an assert, matching the other error-handling style in this loop
## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [ ] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
